### PR TITLE
build: Add support for Python 3.12

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/
@@ -135,7 +135,8 @@ dmypy.json
 .pyre/
 /analytics.json
 
-# VS Code
+# IDEs
+.idea
 .vscode/
 
 # Ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,24 @@ version = "0.0.1"
 description = "`target-csv` is a Singer target for CSV, built with the Meltano SDK for Singer Targets."
 authors = ["Meltano <hello@meltano.com>"]
 license = "Apache-2.0"
+keywords = [
+    "CSV",
+    "Singer",
+    "ELT",
+    "ETL",
+    "Meltano",
+    "Meltano SDK",
+]
+classifiers = [
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
 
 [tool.poetry.dependencies]
 python = ">=3.8"

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
 [testenv:pytest]
 # Run the python tests.
 # To execute, run `tox -e pytest`
-envlist = py37, py38, py39, py310, py311
+envlist = py37, py38, py39, py310, py311, py312
 commands =
     poetry install -v
     poetry run pytest


### PR DESCRIPTION
## About

By refreshing a few dependencies, the package seems to also work on Python 3.12.

## Details

The patch has been validated on behalf of a CI run on another patch.

- https://github.com/pyveci/pueblo/pull/47

![image](https://github.com/MeltanoLabs/target-csv/assets/453543/f74c2ed7-88b7-460c-a71c-abfa898f53be)
