### PR TITLE
feat: Automatically create output directory

### DIFF
--- a/target_csv/sinks.py
+++ b/target_csv/sinks.py
@@ -73,7 +73,9 @@ class CSVSink(BatchSink):
 
         filepath = Path(filename)
         if output_path is not None:
-            filepath = Path(output_path) / filepath
+            path = Path(output_path)
+            path.mkdir(parents=True, exist_ok=True)
+            filepath = path / filepath
 
         return filepath
 


### PR DESCRIPTION
## About

This patch intends to add another feature also seen on other file-based targets, to automatically create the output directory, if it doesn't exist.

It is very convenient, because it otherwise needs an inconvenient `mkdir output` command to be squeezed into some preparation task before running the Meltano project, or as a separate step into the Meltano project itself.

## Thoughts

There are many possible outcomes to this.

- There might be policies or tastes which will straightly reject the idea of automatically creating target resources. [^1]
- Conversations about whether it makes sense or not.
- Acknowledgement without further ado.

None of them will happen as-is, but I'm prepared to accept any outcome ;], and will be happy to receive your guidance about whether and how you would like this feature to be integrated.

## Backlog

- [ ] Documentation
- [ ] Software tests
- [ ] A dedicated property to control this feature?

[^1]: Did you have any discussions about this topic yet, or are there actually any policies about how targets/loaders should behave?

